### PR TITLE
fixed indentation

### DIFF
--- a/bugspots/__init__.py
+++ b/bugspots/__init__.py
@@ -121,7 +121,7 @@ def get_code_hotspots(options):
 
             hotspots[filename] += hotspot_factor
 
-    print("      -%s" % message)
+        print("      -%s" % message)
 
     sorted_hotspots = sorted(hotspots, key=hotspots.get, reverse=True)
 


### PR DESCRIPTION
The current indentation keeps the print statement out of the loop and hence only the last matching message is printed to console. Moving it inside the for loop prints all the relevant messages in the matching commits.  
![Uploading Screenshot 2021-06-24 at 8.01.32 PM.png…]()  
Only one fix message is shown above, although 463 bugfixes count reported.